### PR TITLE
stop throwing exception for non selenium tests

### DIFF
--- a/pytest_tags/pytest_tags.py
+++ b/pytest_tags/pytest_tags.py
@@ -25,7 +25,8 @@ def pytest_configure(config):
 
     # Create tags container based on command line parameters
     browser = None
-    if hasattr(config.option, 'driver'):
+    driver = getattr(config.option, 'driver', None)
+    if driver:
         browser = config.option.driver.lower()
 
     config.parameter_tags = tagging.TagsParameter(browser,


### PR DESCRIPTION
Earlier it made assumption of driver being available, which would throw stack trace and stop pytest from running, if user wants to write plain non selenium tests.